### PR TITLE
Fix highlight by using Prism instead of PrismAsync

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "start": "vite",
     "start:mock": "vite --mode mock",
     "build": "vite build",
+    "build:mock": "vite build --mode mock",
     "build:gh-pages": "vite build --mode gh-pages",
     "build-and-zip": "vite build && ./scripts/zip-dist.sh",
     "init-mock": "npx msw init public --no-save",

--- a/src/components/SubmissionDetail.tsx
+++ b/src/components/SubmissionDetail.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { PrismAsyncLight as SyntaxHighlighter } from "react-syntax-highlighter";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { SubmissionServiceModel } from "../typings/submission";
 import { CopyToClipboard } from "react-copy-to-clipboard";


### PR DESCRIPTION
We should still track this issue until it's solved.
https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/263

Using PrismAsync don't seem to be good enough to me, user will get some seconds to load styles with a very wierd output if there network is bad.

I also add a build:mock option so that we can test static build locally with NPM http-server or Ngnix.